### PR TITLE
Added "unused" modifier to function definitions in food and drink ite…

### DIFF
--- a/pkg/items/food_drink/drink/method.src
+++ b/pkg/items/food_drink/drink/method.src
@@ -1,14 +1,13 @@
 /* $Id: method.src 471 2006-06-28 00:07:48Z austinheilman $
  *
  */
- 
+
 use uo;
 
 program Install()
 	return 1;
 endprogram
 
-exported function IsDrink(item)
-	item := item; // To avoid unused var warnings
+exported function IsDrink(unused item)
 	return 1;
 endfunction

--- a/pkg/items/food_drink/drink/use.src
+++ b/pkg/items/food_drink/drink/use.src
@@ -8,27 +8,34 @@ include ":timedScripts:timedScripts";
 include ":itemutils:itemdesc";
 include "include/client";
 include "include/sounds";
-
-program use_Drink(character, drink)
+include "include/math";
+program use_Drink(who, drink)
 	if( drink.movable == 0 )
-		SendSysMessage(character, "You cannot drink that.");
+		SendSysMessage(who, "You cannot drink that.");
 		return 0;
 	endif
 
 	var cfg_elem := GetItemDescInfo(drink.objtype);
 	var proof := GetConfigInt(cfg_elem, "Proof");
-	var poison := CInt(GetObjProperty(drink, "PoisonLevel"));
+	var strength := CInt(GetObjProperty(drink, "PoisonStrength"));
+	var duration := CInt(GetObjProperty(drink, "duration"));
 
 	SubtractAmount(drink, 1);
-	PerformAction(character, ANIM_EAT);
-	PlaySoundEffect(character, SFX_DRINK_1);
+	PerformAction(who, ANIM_EAT);
+	PlaySoundEffect(who, SFX_DRINK_1);
 	Sleep(2);
 
-	if ( poison > 0 )
-		TS_StartTimer(character, "DefaultPoison", 120, poison, character);
-	endif
 	if ( proof )
-		TS_StartTimer(character, "Alcohol", proof*10);
+		TS_StartTimer(who, "Alcohol", proof*10);
+	endif
+	if ( strength > 0 )
+		// If the beverage is alcoholic the strength of the alcohol
+		// will increase the duration of the poison timer.
+		var modifier := (proof * 0.01) * 4;
+		duration := CInt(duration + (duration * modifier));
+		// Round up to the nearest tens place.
+		duration := RoundToTens(duration, ROUND_UP);
+		TS_StartTimer(who, "DefaultPoison", duration, strength);
 	endif
 
 	return 1;

--- a/pkg/items/food_drink/food/method.src
+++ b/pkg/items/food_drink/food/method.src
@@ -1,14 +1,13 @@
 /* $Id: method.src 471 2006-06-28 00:07:48Z austinheilman $
  *
  */
- 
+
 use uo;
 
 program Install()
 	return 1;
 endprogram
 
-exported function IsFood(item)
-	item := item; // To avoid unused var warnings
+exported function IsFood( unused item )
 	return 1;
 endfunction

--- a/pkg/items/food_drink/food/use.src
+++ b/pkg/items/food_drink/food/use.src
@@ -23,7 +23,9 @@ program eat(who, food)
 
 	var cfg_elem := GetItemDescInfo(food.objtype);
 	var themsg;
-	var poison := CInt(GetObjProperty(food, "PoisonLevel"));
+	var strength := CInt(GetObjProperty(food, "PoisonStrength"));
+	var duration := CInt(GetObjProperty(food, "duration"));
+
 	var foodvalue := CInt(cfg_elem.foodvalue);
 
 	var hunger := AP_GetVital(who, "Hunger");
@@ -105,8 +107,8 @@ program eat(who, food)
 		endcase
 	endif
 
-	if ( poison > 0 )
-		TS_StartTimer(who, "defaultPoison", 120, poison, who);
+	if ( strength > 0 )
+		TS_StartTimer(who, "DefaultPoison", duration, strength);
 	endif
 
 	return 1;

--- a/pkg/skills/alchemy/greenPotion.src
+++ b/pkg/skills/alchemy/greenPotion.src
@@ -47,5 +47,5 @@ function do_poison(who, potion)
 		return 0;
 	endif
 	*/
-	TS_StartTimer(who, "DefaultPoison", 120, strength, who);
+	TS_StartTimer(who, "DefaultPoison", 120, strength);
 endfunction

--- a/pkg/skills/poisoning/poisonSkill.src
+++ b/pkg/skills/poisoning/poisonSkill.src
@@ -53,10 +53,6 @@ program do_poisoning( who )
     SendSysMessageCL(who, 502142 ); // To what do you wish to apply the poison?
     the_item := Target(who, TGTOPT_CHECK_LOS);
     if (!the_item)
-		SendSysMessageCL(who, 1042023); // Cancelled.
-		return 0;
-    endif
-    if (!the_item)
 		SendSysMessageCL(who, 1042023, color := 33); // Cancelled.
 		return 0;
     endif
@@ -72,19 +68,20 @@ program do_poisoning( who )
 		SendSysMessageCL(who, 501975, color := 33); // That is too far away.
 		return 0;
     endif
+    if(!the_item.IsFood() && !the_item.IsDrink() && the_item.Attribute != "Swordsmanship" && the_item.Attribute != "Fencing")
+    	SendSysMessageCL(who, 502145, color := 33); // You cannot poison that! You can only poison bladed or piercing weapons, food or drink.)
+    	return 0;
+    endif
     var potion_strength :=FindConfigElem(alchemy_itemdesc_file, the_poison.objtype);
 	stren :=CInt(GetConfigInt(potion_strength, "strength"));
 	if(stren.errortext)
 		SysLog("No 'strength' entry for poison potion in alchemy itemdesc file.");
 		return;
 	endif
-    var acfgfile;
-    var theitem := FindConfigElem( acfgfile, CInt(the_item.objtype) );
-    if (!theitem)
-		acfgfile := ReadConfigFile(":combat:itemdesc");
-		theitem := acfgfile[the_item.objtype];
-	    if (theitem)
-			if ((theitem.attribute == "Swords") || (theitem.attribute == "Fencing"))
+	var duration := 90;
+ 	//    if (SkillCheck( who, POISONING, -1, 10))
+			if ((the_item.Attribute == "Swordsmanship") || (the_item.Attribute == "Fencing"))
+				Print("Swordsmanship");
 				if (stren == 0)
 					stren := 1;
 				endif
@@ -98,19 +95,19 @@ program do_poisoning( who )
 				4:	skill := 88;
 					point := 290;
 				endcase
-				var duration := 25 - stren;
-	// Didn't mess with the skill gains here until we see how it pans out 08-05-2011
+				// Didn't mess with the skill gains here until we see how it pans out 08-05-2011
 				if (SkillCheck( who, POISONING, skill, point/10) + 20)
-					SetObjProperty(the_item, "poison_level", stren*2);
-					SetObjProperty(the_item, "duration", duration);
-					var hitscripts := GetObjProperty(the_item, "OnHit");
-					var previouspoison := GetObjProperty(the_item, "phit");
+
+					SubtractAmount(the_poison,1);
+					CreateItemInBackpack(who, UOBJ_EMPTY_BOTTLE, 1);
 					PlaySoundEffect(who, 0x248);
 					SetObjProperty(the_item, "PoisonStrength", stren);
+					SetObjProperty(the_item, "duration", duration);
 
 					SendSysMessageCL(who, 1010517, color := 66 ); // You apply the poison
 
-					// We are hanging from a separate poison hit script to
+					//////////////////////////////////////////////////////////////////////
+					// We are changing from a separate poison hit script to
 					// inclusion of poison hit in mainHitScript.
 					// The commented out lines are left in here for
 					// future reference in the event we, or someone else,
@@ -124,51 +121,35 @@ program do_poisoning( who )
 
 					if (previouspoison != 1)
 						SetObjProperty(the_item, "OnHit", hitscripts);
-					endif 
-					SetObjProperty(the_item, "phit", 1); */
-
-					// Adjust the following virtues negatively for poisoning a weapon.
-					case(stren)
-						1:	VS_AdjustVirtue(who, "honor", -1, prob := 35);
-							VS_AdjustVirtue(who, "compassion", -1, 35);
-						2:	VS_AdjustVirtue(who, "honor", -1, 50);
-							VS_AdjustVirtue(who, "compassion", -1, 50);
-						3:	VS_AdjustVirtue(who, "honor", -1, 65);
-							VS_AdjustVirtue(who, "compassion", -1, 65);
-						4:	VS_AdjustVirtue(who, "honor", -1, 80);
-							VS_AdjustVirtue(who, "compassion", -1, 80);
-					endcase
-				else
-					if (RandomInt(100) > GetAttribute(who, POISONING))
-						SendSysMessageCL(who, 502148, color := 33); // You make a grave mistake while applying the poison.
-						SendSysMessage(who, "You fail, and poison yourself!");
-						TS_StartTimer(who, "DefaultPoison", duration, stren, who);
-						SetObjProperty(who, "poison_level", stren);
-						start_script(":spells:poisondamage", who);
-					else
-						SendSysMessage(who, "You fail to apply the poison properly.");
 					endif
+					SetObjProperty(the_item, "phit", 1); */
+					/////////////////////////////////////////////////////////////////////////
+
+					// Drop virtues.
+					VirtueDrop(who, stren);
+					return 1;
+				else
+					// Check to determine if the player was accidentally poisoned.
+					SelfPoisonCheck(who, stren);
+					return 0;
 				endif
-				SubtractAmount(the_poison,1);
-				CreateItemInBackpack(who, UOBJ_EMPTY_BOTTLE, 1);
-				return 1;
 			elseif((the_item.objtype == 0xf3f) || (the_item.objtype == 0x1bfb)) // arrow and crossbow bolt
-				SubtractAmount(the_poison,1);
 				if(!ReserveItem(the_item))
 					SendSysMessage(who,"cancelled");
 					return 0;
 				endif
 				if(the_item.amount < 10)
 					SendSysMessage(who,"Those must be poisoned in groups of 10.");
-					return;
+					return 0;
 				endif
-	//		if (SkillCheck( who, POISONING, -1, 100))
+				SubtractAmount(the_poison,1);
+				CreateItemInBackpack(who, UOBJ_EMPTY_BOTTLE, 1);
 				if (SkillCheck( who, POISONING, -1, 10))
 					var obj := the_item.objtype;
-					if(!SubtractAmount(the_item, 10))
-						SendSysMessage(who,"Those must be poisoned in groups of 10.");
-						return 0;
-					endif
+//					if(!SubtractAmount(the_item, 10))
+//						SendSysMessage(who,"Those must be poisoned in groups of 10.");
+//						return 0;
+//					endif
 					var objtype;
 					// Convert arrows and crossbow bolts to the poisoned versions.
 					case(obj)
@@ -178,46 +159,34 @@ program do_poisoning( who )
 					CreateItemInBackpack( who, objtype, 10 );
 					PlaySoundEffect(who, 0x248);
 					SendSysMessage(who, "You poison some arrows and put them in your backpack");
-					// Adjust the following virtues negatively for poisoning a weapon.
-					// A harsher virtue adjustment because ten arrows were done at once.
-					case(stren)
-						1:	VS_AdjustVirtue(who, "honor", -3, prob := 35);
-							VS_AdjustVirtue(who, "compassion", -3, 35);
-						2:	VS_AdjustVirtue(who, "honor", -3, 50);
-							VS_AdjustVirtue(who, "compassion", -3, 50);
-						3:	VS_AdjustVirtue(who, "honor", -3, 65);
-							VS_AdjustVirtue(who, "compassion", -3, 65);
-						4:	VS_AdjustVirtue(who, "honor", -3, 80);
-							VS_AdjustVirtue(who, "compassion", -3, 80);
-					endcase
-
+					// Drop virtues.
+					VirtueDrop(who, stren);
+					return 1;
 				else
-					if (RandomInt(100) > GetAttribute(who, POISONING))
-						SendSysMessage(who, "You fail, and poison yourself!");
-						SetObjProperty(who, "poison_level", (RandomInt(20) + 10));
-						start_script(":spells:poisondamage", who);
-					else
-						SendSysMessage(who, "You fail to apply the poison properly.");
-					endif
+					// Check to determine if the player was accidentally poisoned.
+					SelfPoisonCheck(who, stren);
+					return 0;
 				endif
+			elseif (the_item.IsFood() || the_item.IsDrink())
+				SubtractAmount(the_poison,1);
 				CreateItemInBackpack(who, UOBJ_EMPTY_BOTTLE, 1);
+				if (SkillCheck( who, POISONING, skill, point/10) + 20)
+					PlaySoundEffect(who, 0x248);
+					SetObjProperty(the_item, "PoisonStrength", stren);
+					SetObjProperty(the_item, "duration", duration);
+					SendSysMessageCL(who, 1010517, color := 66 ); // You apply the poison
+					VirtueDrop(who, stren);
+					return 1;
+				else
+					// Check to determine if the player was accidentally poisoned.
+					SelfPoisonCheck(who, stren);
+					return 0;
+				endif
 			else
 				SendSysMessage(who, "That cannot be poisoned.");
+				return 0;
 		    endif
-		endif
-		if (!theitem)
-			if (the_item.usescript["eat"] || the_item.usescript["drink"])
-				theitem := the_item;
-			// The commented line below was the original line.
-			// Left it here for debugging purposes.
-			// elseif (alchcfg[the_item.objtype])
-			elseif (alchemy_itemdesc_file[the_item.objtype])
-				theitem := theitem;
-			else
-				return;
-			endif
-		endif
-    endif
+		 // endif
 endprogram
 
 
@@ -231,3 +200,26 @@ function poisonArrows (arrow)
 
 endfunction
 
+function VirtueDrop(player, strength)
+	// Adjust the following virtues negatively for poisoning a weapon.
+	case(strength)
+		1:	VS_AdjustVirtue(player, "honor", -3, prob := 35);
+			VS_AdjustVirtue(player, "compassion", -3, 35);
+		2:	VS_AdjustVirtue(player, "honor", -3, 50);
+			VS_AdjustVirtue(player, "compassion", -3, 50);
+		3:	VS_AdjustVirtue(player, "honor", -3, 65);
+			VS_AdjustVirtue(player, "compassion", -3, 65);
+		4:	VS_AdjustVirtue(player, "honor", -3, 80);
+			VS_AdjustVirtue(player, "compassion", -3, 80);
+	endcase
+endfunction	
+
+function SelfPoisonCheck(who, strength)
+	if (RandomInt(100) > GetAttribute(who, POISONING))
+		SendSysMessageCL(who, 502148, color := 33); // You make a grave mistake while applying the poison.
+		SendSysMessage(who, "You fail, and poison yourself!");
+		TS_StartTimer(who, "DefaultPoison", 120, strength, who);
+	else
+		SendSysMessage(who, "You fail to apply the poison properly.");
+	endif
+endfunction

--- a/pkg/systems/combat/config/syshook.cfg
+++ b/pkg/systems/combat/config/syshook.cfg
@@ -8,7 +8,7 @@ SystemHookScript hooks/parryAdv.ecl
 	ParryAdvancement	ParryAdvancement
 }
 
-SystemHookScript hooks/combatHook.ecl
-{
-	Attack	Attack
-}
+#SystemHookScript hooks/combatHook.ecl
+#{
+#	Attack	Attack
+#}

--- a/pkg/systems/combat/mainHitScript.src
+++ b/pkg/systems/combat/mainHitScript.src
@@ -27,7 +27,7 @@ include ":damage:damage";
 var item_cfg := ReadConfigFile(":*:itemdesc");
 
 program MainHitScript(attacker, defender, weapon, armor, basedamage, rawdamage)
-
+	Print("In mainHitScript");
 	//
 	// Cheat checker
 	//
@@ -79,7 +79,7 @@ program MainHitScript(attacker, defender, weapon, armor, basedamage, rawdamage)
 	DamageInfo(attacker, defender, basedamage, rawdamage);
 	WeaponHitScripts(attacker, defender, weapon, armor, basedamage, rawdamage);
 	ArmorHitScripts(attacker, defender, weapon, armor, basedamage, rawdamage);
-	//PoisonChecks(attacker, defender, weapon, armor, basedamage, rawdamage);
+	PoisonChecks(attacker, defender, weapon, armor, basedamage, rawdamage);
 
 	var hostiles := ListHostiles(defender, 1);
 	rawdamage := rawdamage+CInt(hostiles.Size()/2);
@@ -238,8 +238,9 @@ endfunction
 
 function PoisonChecks(attacker, defender, weapon, armor, basedamage, rawdamage)
 
-	var PoisonStrength := GetObjProperty(weapon, "PoisonStrength");
+	var PoisonStrength := CInt(GetObjProperty(weapon, "PoisonStrength"));
 	var duration := CInt(GetObjProperty(weapon, "duration"));
+	Print(CStr(PoisonStrength) + "    " + CStr(duration));
 
 	if ( PoisonStrength )
 		TS_StartTimer(defender, "DefaultPoison", duration, PoisonStrength, attacker);

--- a/pkg/utils/timedScripts/config/timedScripts.cfg
+++ b/pkg/utils/timedScripts/config/timedScripts.cfg
@@ -146,7 +146,7 @@ TimerElem alcohol
 	NoCure			1
 	Cumulative		1
 	EndMessage		You feel sober again.
-	MaxDuration		300	//  minutes
+	MaxDuration		300	// 5 minutes
 }
 
 #--=[ Alchemy Skill ]=--------------------
@@ -161,6 +161,8 @@ TimerElem agilitypotion
 	Cumulative		0
 	Type			B
 	BuffIcon		1045
+   cliloc_name		0x106a81
+   cliloc_desc		0x106a82
 }
 
 TimerElem strengthpotion
@@ -173,6 +175,8 @@ TimerElem strengthpotion
 	Cumulative		0
 	Type			B
     BuffIcon		1047
+   cliloc_name		0x106a85
+   cliloc_desc		0x106a86
 }
 
 #--=[ Magery Skill ]=--------------------

--- a/pkg/utils/timedScripts/include/buffIcon.inc
+++ b/pkg/utils/timedScripts/include/buffIcon.inc
@@ -33,6 +33,8 @@ endfunction
 // function SendBuffIcon( mobile, icon, modifier, duration, cliloc_name, cliloc_desc ) // cfg cliloc stuff.
 function SendBuffIcon( mobile, icon, modifier, duration )
 
+        Print("Buff icon is " + CStr(icon));
+
         if( mobile.IsA( POLCLASS_NPC ))
                 return 0;
         endif
@@ -136,6 +138,11 @@ function GetClilocsInfo( icon )
                            cliloc_name := 1075825;
                            cliloc_desc := 1075826;
                            break;
+                1038:      // Poison
+                           cliloc_name := 0x0F8627;
+                           cliloc_desc := 0x1069B1;
+                           break;
+
         endcase
         
         return array{cliloc_name, cliloc_desc};

--- a/scripts/include/math.inc
+++ b/scripts/include/math.inc
@@ -60,6 +60,10 @@ use math;
 const CONST_E := 2.718282;
 const CONST_PI := 3.141592;
 
+// Used in the RoundToTens() function
+const ROUND_NORMAL := 0;
+const ROUND_DOWN := 1;
+const ROUND_UP := 2;
 
 ///////////////////////////////////////////////////////////
 //
@@ -770,4 +774,46 @@ endfunction
  */
 function IsBitOn ( value, shift_by )
 	return ( 1 & ( value >> shift_by ) );
+endfunction
+
+///////////////////////////////////////////////////////////////////////////////////////////////
+//
+// function RoundToTens( n, behaviour := NORMAL )
+// Purpose: Round the passed number to an even multiple of 10.
+// Examples:	RoundToTen( 145 ) will return 140.
+//						RoundToTen( 146 ) will return 150.
+// Parameters:	n - Is converted to an integer.
+//						behaviour - constant as defined below.
+//						ROUND_NORMAL will round up or down using normal rounding
+//						rules, ie. if n is in the range of 140 - 145 it will return140.
+//						if n is in the range of 146 to 150 it will return 150.
+//						ROUND_DOWN will always round down to the nearest tens
+//						place, ie. if n is between 140 - 149 it will return 140.
+//						ROUND_UP will always round up to the nearest tens
+//						place, ie. if n is between 140 - 149 it will return 150.
+//
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+function RoundToTens( n, behaviour := ROUND_NORMAL )
+	n := CInt(n);
+
+    // Smaller multiple
+    var a := (n / 10) * 10;
+
+    // Larger multiple
+    var b := a + 10;
+
+    // Return to even tens place
+	if(behaviour  == ROUND_NORMAL)
+		if(n-a > b -n)
+			return b;
+		else
+			return a;
+		endif
+	elseif(behaviour == ROUND_DOWN)
+			return a;
+	elseif(behaviour == ROUND_UP)
+			return b;
+	endif
+
 endfunction


### PR DESCRIPTION
…ms method scripts.

Fixed poisonSkill.src to work with timedScripts. Weapons, food and drink can be poisoned.
Disabled Attack syshook. Attacks will now be handled by mainHitScript.src in :combat. Needs testing.
Added functionality to the PoisonChecks function in mainHitScript.src.
Fixed eating and drinking poisoned food and drink in the respective use.src scripts.
Added poison buff info to bufficon.inc.
Added cliloc info to the timedScripts.cfg. I plan to read that info from the cfg rather than have the long case statement in bufficon.inc.
Added RoundToTens function to math.inc. See the file for a description.