### PR TITLE
Update servspecopt.cfg for EnableWorldMapPackets

### DIFF
--- a/config/servspecopt.cfg
+++ b/config/servspecopt.cfg
@@ -396,3 +396,10 @@ MobilesBlockNpcMovement=1
 #
 DefaultAccessibleRange=18
 
+# EnableWorldMapPackets - 1/0 (default 0)
+#
+# Custom clients have implemented a packet that tracks the position of party and 
+# guild members. This enables the client to overlay member positions on a world 
+# map directly inside the client. Set to 1 to enable core handling of this packet. 
+#
+EnableWorldMapPackets=0


### PR DESCRIPTION
With https://github.com/polserver/polserver/pull/126 we now support the World Map packets. This adds the configuration to the config file and keeps the default; more of a documentation purpose, allowing individual shard owners to change as necessary.