### PR TITLE
Added serverlist hook. Modernized from an old package by tekproxy.

### DIFF
--- a/pkg/optional/serverlist_hook/config/icp.cfg
+++ b/pkg/optional/serverlist_hook/config/icp.cfg
@@ -1,0 +1,17 @@
+# $Id: icp.cfg 1044 2007-04-19 02:09:04Z tekproxy $
+
+ICP Register
+{
+	Name		ServerList
+	Version		2
+
+	Description	Handles UOGateway and ConnectUO status requests.
+
+	Creator		tekproxy
+	C_Email		tekproxy@gmail.com
+
+	Maintainer	Distro Team
+	M_Email		distro@polserver.com
+	
+	// Script	cmdlevel	path
+}

--- a/pkg/optional/serverlist_hook/config/settings.cfg
+++ b/pkg/optional/serverlist_hook/config/settings.cfg
@@ -1,0 +1,24 @@
+Elem Settings
+{
+	ServerName Modern Distro
+	ServerURL https://www.polserver.com
+	ServerEmail polteam@polserver.com
+	
+	// RAM, in MB
+	PhysicalMemory 0
+	
+	// Include debug messages?
+	Debug 0
+    
+    // Tell the number of items?
+    ShowItems 0
+    
+    // Tell the number of mobiles?
+    ShowMobiles 0
+    
+    // Text format when replying to subcommand 0xFF
+    // Valid values: ConnectUO or UOGateway
+    TextReplyFormat ConnectUO
+
+    Enabled 1
+}

--- a/pkg/optional/serverlist_hook/config/uopacket.cfg
+++ b/pkg/optional/serverlist_hook/config/uopacket.cfg
@@ -1,0 +1,8 @@
+# $Id: uopacket.cfg 1045 2007-04-20 13:17:45Z tekproxy $
+
+Packet 0xF1
+{
+  Length variable
+  SendFunction doServerList:handleSendStatusRequest
+  ReceiveFunction doServerList:handleRecvStatusRequest
+}

--- a/pkg/optional/serverlist_hook/doServerList.src
+++ b/pkg/optional/serverlist_hook/doServerList.src
@@ -1,0 +1,89 @@
+// $Id: doServerList.src 1045 2007-04-20 13:17:45Z tekproxy $
+// 2021-03-13 - Updated to modern standards by Nando
+
+use uo;
+use os;
+use polsys;
+
+include ":serverlist:settings";
+
+program doServerList()
+	Print("INSTALLING: ServerList PH...");
+
+	return 1;
+endprogram
+
+exported function handleSendStatusRequest(connection, byref packet)
+	return 0;
+endfunction
+
+// 0xF1 subcommands that we know
+const SERVERLIST_TXTSTATUS := 0xFF;
+
+exported function handleRecvStatusRequest(connection, byref request_packet)
+    print("[0xF1 status info] Request received from {}".format(connection.ip));
+    var settings := SL_GetSettingsCfgElem("Settings");
+    
+    if (!settings.Enabled)
+        return 0;
+    endif
+    
+    var subcmd := request_packet.GetInt8(3);
+    case (subcmd)
+        SERVERLIST_TXTSTATUS:
+            var status := GetTextStatus(settings);
+            SendTextReply(connection, status);
+    endcase
+
+    DisconnectClient(connection);
+    return 1;
+endfunction
+
+function online_count() 
+    return Len(EnumerateOnlineCharacters());
+endfunction
+
+function GetTextStatus(byref settings)
+    case (settings.TextReplyFormat)
+        "UOGateway": return GetUOGatewayStatus();
+        "ConnectUO":
+            default: return GetConnectUOStatus();
+    endcase
+endfunction
+
+function SendTextReply(byref connection, status)
+    var len_status := Len(status);
+
+    var packet_status := CreatePacket(CInt(status[1]), len_status);
+    packet_status.SetString(0, status, 0);
+    return packet_status.SendPacket(connection);
+endfunction
+
+
+
+// ConnectUO expects: Name Age Clients Items Chars Mem
+function GetConnectUOStatus()
+	var settings := SL_GetSettingsCfgElem("Settings");
+	var memory := CInt(GetConfigInt(settings, "PhysicalMemory") / 1024);
+	
+    var status_string := "POL, Name={}, Age={}, Clients={}, Items={}, Chars={}, Mem={}K";
+    var item_count := 0;
+    if (settings.ShowItems)
+        item_count := PolCore().itemcount;
+    endif
+    
+    var mob_count := 0;
+    if (settings.ShowMobiles)
+        mob_count := PolCore().mobilecount;
+    endif
+    
+    return status_string.format(settings.ServerName, PolCore().uptime, online_count(), item_count, mob_count, memory);
+endfunction
+
+// UOGateway expects: Name Age Ver TZ EMail URL Clients
+function GetUOGatewayStatus()
+	var settings := SL_GetSettingsCfgElem("Settings");
+    var status_string := "POL, Name={}, Age={}, Ver={}, TZ={}, EMail={}, URL={}, Clients={}";
+    
+    return status_string.format(settings.ServerName, CInt(ReadGameClock()/86400), PolCore().verstr, 1, settings.ServerEmail, settings.ServerURL, online_count());
+endfunction

--- a/pkg/optional/serverlist_hook/docs/example_pollstatus.py
+++ b/pkg/optional/serverlist_hook/docs/example_pollstatus.py
@@ -1,0 +1,20 @@
+import socket;
+import time;
+
+print('Connecting...')
+sock = socket.create_connection(('localhost',5003))
+sock.settimeout(2);
+
+seed = bytes([0x01, 0x02, 0x03, 0x04])
+bts = bytes([0xF1, 0x00, 0x04, 0xFF])
+
+sock.send(seed)
+sock.send(bts)
+
+while sock:
+    rcv = sock.recv(1024)
+    if (not rcv):
+        break 
+    print(rcv)
+    
+print('End')

--- a/pkg/optional/serverlist_hook/docs/readme.txt
+++ b/pkg/optional/serverlist_hook/docs/readme.txt
@@ -1,0 +1,17 @@
+Polling a server
+----------------
+To receive a status reply, a client needs to send:
+1. 4 bytes for the seed (anything works)
+2. 0xF1, 0x00, 0x04, 0xFF
+
+For an example of how to poll a shard, see example_pollstatus.py
+
+Requirements
+------------
+This package requires the final release of POL 100.0.0. 
+Anything older has a crash bug when calling DisconnectClient()
+from within the packet hook.
+
+If "DisconnectClient()" is removed from doServerList.src, this
+package can work from POL99 onwards. But note that the client
+must then disconnect by itself after receiving the reply.

--- a/pkg/optional/serverlist_hook/include/settings.inc
+++ b/pkg/optional/serverlist_hook/include/settings.inc
@@ -1,0 +1,33 @@
+use uo;
+use os;
+use cfgfile;
+
+function SL_GetSettingsCfgFile()
+	var cfg := ReadConfigFile(":serverlist:settings");
+
+	if ( cfg.errortext )
+		SysLog("Error::SL_GetSettingsCfgFile() - Unable to open [:settings:settings.cfg] ->"+cfg.errortext);
+	endif
+
+	return cfg;
+endfunction
+
+function SL_GetSettingsCfgElem(elem_name, byref cfg_file:=0)
+	if ( !cfg_file )
+		cfg_file := SL_GetSettingsCfgFile();
+	endif
+	
+	var elem := cfg_file[elem_name];
+
+	if ( elem.errortext )
+		SysLog("Error::SL_GetSettingsCfgElem() - Unable to find elem ["+elem_name+"] ->"+elem.errortext);
+	endif
+
+	return elem;
+endfunction
+
+function SL_CheckDebug()
+	var settings_elem := SL_GetSettingsCfgElem("Settings");
+	
+	return GetConfigInt(settings_elem, "Debug");
+endfunction

--- a/pkg/optional/serverlist_hook/pkg.cfg
+++ b/pkg/optional/serverlist_hook/pkg.cfg
@@ -1,0 +1,18 @@
+# $Id: pkg.cfg 1048 2007-04-23 00:56:15Z tekproxy $
+# Updated on 2021-03-13 by Nando
+
+Enabled		1
+Name		serverlist
+
+Version		2.0
+
+CoreRequired	100.0.0
+
+Creator		tekproxy
+Email		tekproxy@gmail.com
+
+Maintainer	Distro Team
+Email		distro@polserver.com
+
+#Conflicts	none
+#Requires	none


### PR DESCRIPTION
Polling a server
----------------
To receive a status reply, a client needs to send:
1. 4 bytes for the seed (anything works)
2. 0xF1, 0x00, 0x04, 0xFF

For an example of how to poll a shard, see example_pollstatus.py

Requirements
---------------
This package requires the final release of POL 100.0.0. 
Anything older will crash when calling DisconnectClient() from within the packet hook.

If "DisconnectClient()" is removed from doServerList.src, this package can work from POL99 onwards. But note that the client must then disconnect by itself after receiving the reply (e.g., must have a timeout).