### PR TITLE
Update compile.yml

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,7 +14,7 @@ jobs:
           unzip Nightly-Linux-clang.zip
           rm -f *_dbg.zip
           rm -f Nightly-Linux-clang.zip
-          unzip -j -o polserver*.zip"
+          unzip -j -o polserver*.zip
           cp ecompile scripts/
           cp *.em scripts/
           echo "ModuleDirectory=scripts" >>scripts/ecompile.cfg

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install latest ecompile
         run: |
           wget -q https://github.com/polserver/polserver/releases/download/NightlyRelease/Nightly-Linux-clang.zip
           unzip Nightly-Linux-clang.zip
           rm -f *_dbg.zip
           rm -f Nightly-Linux-clang.zip
-          unzip -j -o *.zip
+          unzip -j -o polserver*.zip"
           cp ecompile scripts/
           cp *.em scripts/
           echo "ModuleDirectory=scripts" >>scripts/ecompile.cfg


### PR DESCRIPTION
"uses: actions/checkout@v2" - v2 seems to be faster and has a "Post job cleanup"


I had an error while using this action script, the line "unzip -j -o \*.zip" didn't work for me. Different from the ModernDistro repo, I have the core + distro inside my repo and because of that I had a conflict with the packets.zip.
So changing this line to "unzip -j -o polserver\*.zip" fixes the problem.
This change makes the script more universal, so shard devs can copy and past it easier.