### PR TITLE
Fixed CreateStackArrayInContainer so it doesn't return error if there…

### DIFF
--- a/scripts/include/std.inc
+++ b/scripts/include/std.inc
@@ -45,7 +45,10 @@ function CreateStackArrayInContainer (container, objtype, amount, limit_per_stac
 	for loops := 1 to (amount/limit_per_stack)
 		result.append(CreateItemInContainer(container, objtype, limit_per_stack));
 	endfor
-	result.append(CreateItemInContainer(container, objtype, amount-(amount/limit_per_stack)*limit_per_stack));
+	var remainder := amount-(amount/limit_per_stack)*limit_per_stack;
+	if (remainder > 0)
+		result.append(CreateItemInContainer(container, objtype, remainder));
+	endif
 	return result;
 endfunction
 


### PR DESCRIPTION
`CreateStackArrayInContainer` returns `A parameter was invalid` error if
`amount-(amount/limit_per_stack)*limit_per_stack) == 0`. So if used for example with `amount 50000` and `limit_per_stack 10000`, it will return an errortext in the last result.

I believe it should pass just fine in such case. Leftover amount should be checked for `greater than zero` prior to creating.
